### PR TITLE
Add Dockerfile to set up RabbitMQ with STOMP plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM rabbitmq:3.13-management
+RUN rabbitmq-plugins enable rabbitmq_stomp


### PR DESCRIPTION
This pull request introduces a new `Dockerfile` to set up a RabbitMQ container with the STOMP plugin enabled. 

Key changes:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R2): Created a new Dockerfile that uses the `rabbitmq:3.13-management` image as the base and enables the `rabbitmq_stomp` plugin to support STOMP protocol.