### PR TITLE
Add queue client

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,7 +1,48 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"log"
+
+	"github.com/bootdotdev/learn-pub-sub-starter/internal/gamelogic"
+	"github.com/bootdotdev/learn-pub-sub-starter/internal/pubsub"
+	"github.com/bootdotdev/learn-pub-sub-starter/internal/routing"
+	amqp "github.com/rabbitmq/amqp091-go"
+)
 
 func main() {
 	fmt.Println("Starting Peril client...")
+
+	connectionString := "amqp://guest:guest@localhost:5672/"
+	conn, err := amqp.Dial(connectionString)
+	if err != nil {
+		log.Fatalf("Failed to connect to RabbitMQ: %s\n", err)
+	}
+	defer conn.Close()
+
+	fmt.Println("Connected to RabbitMQ")
+
+	username, err := gamelogic.ClientWelcome()
+
+	if err != nil {
+		log.Fatalf("Failed to welcome client: %s\n", err)
+	}
+	fmt.Printf("Welcome, %s!\n", username)
+
+	queueName := fmt.Sprintf("%s.%s", routing.PauseKey, username)
+
+	_, _, err = pubsub.DeclareAndBind(
+		conn,
+		routing.ExchangePerilDirect,
+		queueName,
+		routing.PauseKey,
+		int(pubsub.SimpleQueueType(1)),
+	)
+	if err != nil {
+		log.Fatalf("Failed to declare and bind queue: %s\n", err)
+	}
+
+	fmt.Printf("Queue %s declared and bound\n", queueName)
+
+	gamelogic.ClientWelcome()
 }

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -36,13 +36,11 @@ func main() {
 		routing.ExchangePerilDirect,
 		queueName,
 		routing.PauseKey,
-		int(pubsub.SimpleQueueType(1)),
+		pubsub.Transient,
 	)
 	if err != nil {
 		log.Fatalf("Failed to declare and bind queue: %s\n", err)
 	}
 
 	fmt.Printf("Queue %s declared and bound\n", queueName)
-
-	gamelogic.ClientWelcome()
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,6 +7,8 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/bootdotdev/learn-pub-sub-starter/internal/pubsub"
+	"github.com/bootdotdev/learn-pub-sub-starter/internal/routing"
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
@@ -21,6 +23,22 @@ func main() {
 	defer conn.Close()
 
 	fmt.Println("Connected to RabbitMQ")
+
+	channel, err := conn.Channel()
+	if err != nil {
+		log.Fatalf("Failed to open a channel: %s\n", err)
+	}
+	defer channel.Close()
+	fmt.Println("Channel opened")
+
+	err = pubsub.PublishJSON(channel, routing.ExchangePerilDirect, routing.PauseKey, routing.PlayingState{
+		IsPaused: true,
+	})
+
+	if err != nil {
+		log.Fatalf("Failed to publish message: %s\n", err)
+	}
+	fmt.Println("Message published")
 
 	// Create a channel to receive OS signals
 	sigChan := make(chan os.Signal, 1)

--- a/internal/pubsub/pubsub.go
+++ b/internal/pubsub/pubsub.go
@@ -1,0 +1,71 @@
+package pubsub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+// SimpleQueueType represents different types of queues
+type SimpleQueueType int
+
+const (
+	durable SimpleQueueType = iota
+	transient
+)
+
+func PublishJSON[T any](ch *amqp.Channel, exchange, key string, val T) error {
+	// Marshal the value to JSON
+	body, err := json.Marshal(val)
+	if err != nil {
+		return fmt.Errorf("failed to marshal value: %w", err)
+	}
+
+	// Publish the message
+	err = ch.PublishWithContext(context.Background(), exchange, key, false, false, amqp.Publishing{
+		ContentType: "application/json",
+		Body:        body,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to publish message: %w", err)
+	}
+
+	return nil
+}
+
+func DeclareAndBind(conn *amqp.Connection, exchange, queueName, key string, simpleQueueType int) (*amqp.Channel, amqp.Queue, error) {
+	chn, err := conn.Channel()
+
+	if err != nil {
+		return nil, amqp.Queue{}, fmt.Errorf("failed to open channel: %w", err)
+	}
+
+	queue, err := chn.QueueDeclare(
+		queueName,
+		simpleQueueType == int(durable),
+		simpleQueueType == int(transient),
+		simpleQueueType == int(transient),
+		false,
+		nil,
+	)
+
+	if err != nil {
+		return nil, amqp.Queue{}, fmt.Errorf("failed to declare queue: %w", err)
+	}
+
+	err = chn.QueueBind(
+		queue.Name,
+		key,
+		exchange,
+		false,
+		nil,
+	)
+
+	if err != nil {
+		return nil, amqp.Queue{}, fmt.Errorf("failed to bind queue: %w", err)
+	}
+
+	return chn, queue, nil
+}

--- a/internal/pubsub/pubsub.go
+++ b/internal/pubsub/pubsub.go
@@ -35,7 +35,7 @@ func PublishJSON[T any](ch *amqp.Channel, exchange, key string, val T) error {
 	return nil
 }
 
-func DeclareAndBind(conn *amqp.Connection, exchange, queueName, key string, simpleQueueType int) (*amqp.Channel, amqp.Queue, error) {
+func DeclareAndBind(conn *amqp.Connection, exchange, queueName, key string, simpleQueueType SimpleQueueType) (*amqp.Channel, amqp.Queue, error) {
 	chn, err := conn.Channel()
 
 	if err != nil {
@@ -44,9 +44,9 @@ func DeclareAndBind(conn *amqp.Connection, exchange, queueName, key string, simp
 
 	queue, err := chn.QueueDeclare(
 		queueName,
-		simpleQueueType == int(durable),
-		simpleQueueType == int(transient),
-		simpleQueueType == int(transient),
+		simpleQueueType == durable,
+		simpleQueueType == transient,
+		simpleQueueType == transient,
 		false,
 		nil,
 	)

--- a/internal/pubsub/pubsub.go
+++ b/internal/pubsub/pubsub.go
@@ -42,11 +42,13 @@ func DeclareAndBind(conn *amqp.Connection, exchange, queueName, key string, simp
 		return nil, amqp.Queue{}, fmt.Errorf("failed to open channel: %w", err)
 	}
 
+	isTransient := simpleQueueType == Transient
+
 	queue, err := chn.QueueDeclare(
 		queueName,
 		simpleQueueType == Durable,
-		simpleQueueType == Transient,
-		simpleQueueType == Transient,
+		isTransient,
+		isTransient,
 		false,
 		nil,
 	)

--- a/internal/pubsub/pubsub.go
+++ b/internal/pubsub/pubsub.go
@@ -12,8 +12,8 @@ import (
 type SimpleQueueType int
 
 const (
-	durable SimpleQueueType = iota
-	transient
+	Durable SimpleQueueType = iota
+	Transient
 )
 
 func PublishJSON[T any](ch *amqp.Channel, exchange, key string, val T) error {
@@ -44,9 +44,9 @@ func DeclareAndBind(conn *amqp.Connection, exchange, queueName, key string, simp
 
 	queue, err := chn.QueueDeclare(
 		queueName,
-		simpleQueueType == durable,
-		simpleQueueType == transient,
-		simpleQueueType == transient,
+		simpleQueueType == Durable,
+		simpleQueueType == Transient,
+		simpleQueueType == Transient,
 		false,
 		nil,
 	)


### PR DESCRIPTION
This pull request introduces RabbitMQ integration into the project by adding message publishing and queue declaration/binding functionalities. The changes include setting up RabbitMQ connections in the client and server applications, creating utility functions for pub/sub operations, and improving modularity by organizing these functionalities into a new `pubsub` package.

### RabbitMQ Integration:

* **Client-side setup**: Added RabbitMQ connection logic in `cmd/client/main.go`, including queue declaration and binding using the new `pubsub.DeclareAndBind` utility function. This ensures the client can interact with RabbitMQ for message handling.
* **Server-side setup**: Introduced RabbitMQ channel creation and message publishing logic in `cmd/server/main.go`. The server now publishes JSON messages to a RabbitMQ exchange using the new `pubsub.PublishJSON` function.

### New `pubsub` Utility Package:

* **`PublishJSON` function**: Added a generic function in `internal/pubsub/pubsub.go` to publish JSON-encoded messages to a RabbitMQ exchange. This abstracts the message publishing logic for reuse.
* **`DeclareAndBind` function**: Implemented a utility function in `internal/pubsub/pubsub.go` to declare a queue and bind it to a specific exchange and routing key. This simplifies queue setup for both client and server.

### Code Organization:

* **Modular imports**: Updated imports in both `cmd/client/main.go` and `cmd/server/main.go` to include the new `pubsub` and `routing` packages, ensuring better code organization and separation of concerns. [[1]](diffhunk://#diff-619f178fc713edfbdb03c328e1b880ee5a9097f611cd54b10f252c74d485fb92L3-R47) [[2]](diffhunk://#diff-53cd25fc908d5e63cc8675afbd4ff0910572a985a7cfec27f4460eb674f3b98eR10-R11)