### PR TITLE
Add queue client

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -49,4 +49,5 @@ func main() {
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, os.Interrupt)
 	<-signalChan
+	fmt.Println("\nReceived shutdown signal, closing client connection...")
 }

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
+	"os/signal"
 
 	"github.com/bootdotdev/learn-pub-sub-starter/internal/gamelogic"
 	"github.com/bootdotdev/learn-pub-sub-starter/internal/pubsub"
@@ -43,4 +45,8 @@ func main() {
 	}
 
 	fmt.Printf("Queue %s declared and bound\n", queueName)
+
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, os.Interrupt)
+	<-signalChan
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/bootdotdev/learn-pub-sub-starter/internal/gamelogic"
 	"github.com/bootdotdev/learn-pub-sub-starter/internal/pubsub"
 	"github.com/bootdotdev/learn-pub-sub-starter/internal/routing"
 	amqp "github.com/rabbitmq/amqp091-go"
@@ -31,14 +32,48 @@ func main() {
 	defer channel.Close()
 	fmt.Println("Channel opened")
 
-	err = pubsub.PublishJSON(channel, routing.ExchangePerilDirect, routing.PauseKey, routing.PlayingState{
-		IsPaused: true,
-	})
+	gamelogic.PrintServerHelp()
 
-	if err != nil {
-		log.Fatalf("Failed to publish message: %s\n", err)
+	for {
+		words := gamelogic.GetInput()
+		if len(words) == 0 {
+			continue
+		}
+
+		if words[0] == "quit" {
+			fmt.Println("Quitting...")
+			break
+		}
+
+		if words[0] == "pause" {
+			err = pubsub.PublishJSON(channel, routing.ExchangePerilDirect, routing.PauseKey, routing.PlayingState{
+				IsPaused: true,
+			})
+		
+			if err != nil {
+				log.Fatalf("Failed to publish message: %s\n", err)
+			}
+			fmt.Println("Message published")
+
+			fmt.Println("Game paused")
+			continue
+		}
+
+		if words[0] == "resume" {
+			err = pubsub.PublishJSON(channel, routing.ExchangePerilDirect, routing.PauseKey, routing.PlayingState{
+				IsPaused: false,
+			})
+			if err != nil {
+				log.Fatalf("Failed to publish message: %s\n", err)
+			}
+			fmt.Println("Message published")
+
+			fmt.Println("Game resumed")
+			continue
+		}
+
+		fmt.Println("I do not understand that command")
 	}
-	fmt.Println("Message published")
 
 	// Create a channel to receive OS signals
 	sigChan := make(chan os.Signal, 1)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -83,5 +83,5 @@ func main() {
 
 	// Wait for a signal
 	<-sigChan
-	fmt.Println("\nReceived shutdown signal, closing connection...")
+	fmt.Println("\nReceived shutdown signal, closing server connection...")
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -34,6 +34,14 @@ func main() {
 
 	gamelogic.PrintServerHelp()
 
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	
+	defer signal.Stop(sigChan)
+
+	<-sigChan
+	fmt.Println("\nReceived shutdown signal, closing server connection...")
+
 	for {
 		words := gamelogic.GetInput()
 		if len(words) == 0 {
@@ -42,7 +50,7 @@ func main() {
 
 		if words[0] == "quit" {
 			fmt.Println("Quitting...")
-			break
+			os.Exit(0)
 		}
 
 		if words[0] == "pause" {
@@ -51,7 +59,8 @@ func main() {
 			})
 		
 			if err != nil {
-				log.Fatalf("Failed to publish message: %s\n", err)
+				log.Printf("Failed to publish message: %s\n", err)
+				continue
 			}
 			fmt.Println("Message published")
 
@@ -64,7 +73,8 @@ func main() {
 				IsPaused: false,
 			})
 			if err != nil {
-				log.Fatalf("Failed to publish message: %s\n", err)
+				log.Printf("Failed to publish message: %s\n", err)
+				continue
 			}
 			fmt.Println("Message published")
 
@@ -74,14 +84,4 @@ func main() {
 
 		fmt.Println("I do not understand that command")
 	}
-
-	// Create a channel to receive OS signals
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-
-	defer signal.Stop(sigChan)
-
-	// Wait for a signal
-	<-sigChan
-	fmt.Println("\nReceived shutdown signal, closing server connection...")
 }


### PR DESCRIPTION
This pull request introduces enhancements to signal handling and user interaction in both the client and server components of the application. The most significant updates include adding graceful shutdown mechanisms for the client and server, implementing new game commands (`pause`, `resume`, and `quit`) on the server, and improving user feedback.

### Client-Side Enhancements:
* Added signal handling in `cmd/client/main.go` to gracefully shut down the client when an interrupt signal is received.

### Server-Side Enhancements:
* Integrated new commands (`pause`, `resume`, and `quit`) in `cmd/server/main.go` to allow the server to handle game state changes and exit based on user input.
* Added a helper function call (`gamelogic.PrintServerHelp`) to provide guidance on available commands when the server starts. 