### PR TITLE
Add client repl command support

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/bootdotdev/learn-pub-sub-starter/internal/gamelogic"
 	"github.com/bootdotdev/learn-pub-sub-starter/internal/pubsub"
@@ -43,4 +44,55 @@ func main() {
 	}
 
 	fmt.Printf("Queue %s declared and bound\n", queueName)
+
+	// Create new game state
+	gameState := gamelogic.NewGameState(username)
+
+	// REPL loop
+	for {
+		words := gamelogic.GetInput()
+		if len(words) == 0 {
+			continue
+		}
+
+		command := strings.ToLower(words[0])
+
+		switch command {
+		case "spawn":
+			if len(words) != 3 {
+				fmt.Println("Usage: spawn <location> <unit_type>")
+				continue
+			}
+			id := gameState.CommandSpawn(words[1:])
+			fmt.Printf("Unit spawned with ID: %d\n", id)
+
+		case "move":
+			if len(words) != 3 {
+				fmt.Println("Usage: move <location> <unit_id>")
+				continue
+			}
+			move, err := gameState.CommandMove(words[1:])
+			if err != nil {
+				fmt.Printf("Error moving unit: %s\n", err)
+				continue
+			}
+			fmt.Printf("Units moved to %s\n", move.ToLocation)
+
+		case "status":
+			gameState.CommandStatus()
+
+		case "help":
+			gamelogic.PrintClientHelp()
+
+		case "spam":
+			fmt.Println("Spamming not allowed yet!")
+
+		case "quit":
+			gamelogic.PrintQuit()
+			return
+
+		default:
+			fmt.Println("Unknown command. Type 'help' for available commands.")
+		}
+	}
 }

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -63,7 +63,12 @@ func main() {
 				fmt.Println("Usage: spawn <location> <unit_type>")
 				continue
 			}
-			id := gameState.CommandSpawn(words[1:])
+			id, err := gameState.CommandSpawn(words)
+
+			if err != nil {
+				fmt.Printf("Error spawning unit: %s\n", err)
+				continue
+			}
 			fmt.Printf("Unit spawned with ID: %d\n", id)
 
 		case "move":
@@ -71,7 +76,7 @@ func main() {
 				fmt.Println("Usage: move <location> <unit_id>")
 				continue
 			}
-			move, err := gameState.CommandMove(words[1:])
+			move, err := gameState.CommandMove(words)
 			if err != nil {
 				fmt.Printf("Error moving unit: %s\n", err)
 				continue

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -30,6 +30,21 @@ func main() {
 	defer channel.Close()
 	fmt.Println("Channel opened")
 
+	routingKey := fmt.Sprintf("%s.*", routing.GameLogSlug)
+	queueName := "game_logs"
+
+	_, _, err = pubsub.DeclareAndBind(
+		conn,
+		routing.ExchangePerilTopic,
+		queueName,
+		routingKey,
+		pubsub.Durable,
+	)
+	if err != nil {
+		log.Fatalf("Failed to declare and bind queue: %s\n", err)
+	}
+	fmt.Printf("Queue %s declared and bound\n", queueName)
+
 	gamelogic.PrintServerHelp()
 
 	for {

--- a/internal/gamelogic/spawn.go
+++ b/internal/gamelogic/spawn.go
@@ -5,21 +5,21 @@ import (
 	"fmt"
 )
 
-func (gs *GameState) CommandSpawn(words []string) error {
+func (gs *GameState) CommandSpawn(words []string) (int, error) {
 	if len(words) < 3 {
-		return errors.New("usage: spawn <location> <rank>")
+		return 0, errors.New("usage: spawn <location> <rank>")
 	}
 
 	locationName := words[1]
 	locations := getAllLocations()
 	if _, ok := locations[Location(locationName)]; !ok {
-		return fmt.Errorf("error: %s is not a valid location", locationName)
+		return 0, fmt.Errorf("error: %s is not a valid location", locationName)
 	}
 
 	rank := words[2]
 	units := getAllRanks()
 	if _, ok := units[UnitRank(rank)]; !ok {
-		return fmt.Errorf("error: %s is not a valid unit", rank)
+		return 0, fmt.Errorf("error: %s is not a valid unit", rank)
 	}
 
 	id := len(gs.getUnitsSnap()) + 1
@@ -30,5 +30,5 @@ func (gs *GameState) CommandSpawn(words []string) error {
 	})
 
 	fmt.Printf("Spawned a(n) %s in %s with id %v\n", rank, locationName, id)
-	return nil
+	return id, nil
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the client and server functionality, enhancing the game logic and user interaction. The changes include adding a REPL loop to the client, expanding server commands, and modifying the `CommandSpawn` function to return unit IDs. These updates improve usability and provide better feedback to users.

### Client Enhancements:
* Added a REPL loop to the client (`cmd/client/main.go`), enabling users to interact with the game in real time using commands such as `spawn`, `move`, `status`, `help`, `spam`, and `quit`. This includes input parsing, command handling, and error messages for invalid inputs.
* Imported the `strings` package to facilitate command parsing in the REPL loop.

### Server Enhancements:
* Introduced new commands (`pause` and `resume`) in the server (`cmd/server/main.go`) to manage game states. These commands publish messages to RabbitMQ to pause or resume the game, providing feedback to the user.
* Removed unused imports (`os/signal` and `syscall`) and the related signal handling code, simplifying the server's main function.

### Game Logic Improvements:
* Modified the `CommandSpawn` function in `internal/gamelogic/spawn.go` to return a unit ID along with an error, allowing the client to display the ID of newly spawned units. [[1]](diffhunk://#diff-c15a4a405bb771d97c08d825ba6657f056efa0e58ddc5e2acfe2d905fc241922L8-R22) [[2]](diffhunk://#diff-c15a4a405bb771d97c08d825ba6657f056efa0e58ddc5e2acfe2d905fc241922L33-R33)