### PR TITLE
Oc add queue consumers

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -57,7 +57,7 @@ func main() {
 		pubsub.Transient,
 	)
 	if err != nil {
-		log.Fatalf("Failed to declare and bind queue %s: %s\n", queueName, err)
+		log.Fatalf("Failed to declare and bind queue %s: %s\n", armyMovesQueue, err)
 	}
 
 	fmt.Printf("Queue %s declared and bound\n", armyMovesQueue)

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -40,15 +40,37 @@ func main() {
 		pubsub.Transient,
 	)
 	if err != nil {
-		log.Fatalf("Failed to declare and bind queue: %s\n", err)
+		log.Fatalf("Failed to declare and bind queue %s: %s\n", queueName, err)
 	}
 
 	fmt.Printf("Queue %s declared and bound\n", queueName)
+
+	armyMovesRoutingKey := fmt.Sprintf("%s.*", routing.ArmyMovesPrefix)
+	armyMovesQueue := fmt.Sprintf("%s.%s", routing.ArmyMovesPrefix, username)
+	armyQueuesRoutingKey := armyMovesQueue 
+
+	_, _, err = pubsub.DeclareAndBind(
+		conn,
+		routing.ExchangePerilTopic,
+		armyMovesQueue,
+		armyMovesRoutingKey,
+		pubsub.Transient,
+	)
+	if err != nil {
+		log.Fatalf("Failed to declare and bind queue %s: %s\n", queueName, err)
+	}
+
+	fmt.Printf("Queue %s declared and bound\n", armyMovesQueue)
 
 	// Create new game state
 	gameState := gamelogic.NewGameState(username)
 	err = pubsub.SubscribeJSON(conn, routing.ExchangePerilDirect, queueName, routing.PauseKey, pubsub.Transient, handlerPause(gameState))
 
+	if err != nil {
+		log.Fatalf("Failed to subscribe to queue: %s\n", err)
+	}
+
+	err = pubsub.SubscribeJSON(conn, routing.ExchangePerilTopic, armyMovesQueue, armyMovesRoutingKey, pubsub.Transient, handlerMove(gameState))
 	if err != nil {
 		log.Fatalf("Failed to subscribe to queue: %s\n", err)
 	}
@@ -81,12 +103,25 @@ func main() {
 				fmt.Println("Usage: move <location> <unit_id>")
 				continue
 			}
+
 			move, err := gameState.CommandMove(words)
 			if err != nil {
 				fmt.Printf("Error moving unit: %s\n", err)
 				continue
 			}
 			fmt.Printf("Units moved to %s\n", move.ToLocation)
+
+			channel, err := conn.Channel()
+			if err != nil {
+				log.Fatalf("Failed to open a channel: %s\n", err)
+			}
+
+			err = pubsub.PublishJSON(channel, routing.ExchangePerilTopic, armyQueuesRoutingKey, move)
+			if err != nil {
+				log.Fatalf("Failed to publish to exchange %s: %s\n", routing.ExchangePerilTopic, err)
+			}
+
+			fmt.Printf("Moves published to %s\n", armyMovesQueue)
 
 		case "status":
 			gameState.CommandStatus()
@@ -112,5 +147,13 @@ func handlerPause(gs *gamelogic.GameState) func(routing.PlayingState) {
 		defer fmt.Print("> ")
 
 		gs.HandlePause(ps)
+	}
+}
+
+func handlerMove(gs *gamelogic.GameState) func(gamelogic.ArmyMove) {
+	return func(am gamelogic.ArmyMove) {
+		defer fmt.Print("> ")
+
+		gs.HandleMove(am)
 	}
 }

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -21,6 +21,13 @@ func main() {
 	}
 	defer conn.Close()
 
+	channel, err := conn.Channel()
+	if err != nil {
+		log.Fatalf("Failed to open a channel: %s\n", err)
+	}
+
+	defer channel.Close()
+
 	fmt.Println("Connected to RabbitMQ")
 
 	username, err := gamelogic.ClientWelcome()
@@ -110,11 +117,6 @@ func main() {
 				continue
 			}
 			fmt.Printf("Units moved to %s\n", move.ToLocation)
-
-			channel, err := conn.Channel()
-			if err != nil {
-				log.Fatalf("Failed to open a channel: %s\n", err)
-			}
 
 			err = pubsub.PublishJSON(channel, routing.ExchangePerilTopic, armyQueuesRoutingKey, move)
 			if err != nil {

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -47,6 +47,11 @@ func main() {
 
 	// Create new game state
 	gameState := gamelogic.NewGameState(username)
+	err = pubsub.SubscribeJSON(conn, routing.ExchangePerilDirect, queueName, routing.PauseKey, pubsub.Transient, handlerPause(gameState))
+
+	if err != nil {
+		log.Fatalf("Failed to subscribe to queue: %s\n", err)
+	}
 
 	// REPL loop
 	for {
@@ -99,5 +104,13 @@ func main() {
 		default:
 			fmt.Println("Unknown command. Type 'help' for available commands.")
 		}
+	}
+}
+
+func handlerPause(gs *gamelogic.GameState) func(routing.PlayingState) {
+	return func(ps routing.PlayingState) {
+		defer fmt.Print("> ")
+
+		gs.HandlePause(ps)
 	}
 }


### PR DESCRIPTION
This pull request introduces new functionality to handle message subscriptions and publishing in the `cmd/client` application, along with a utility function for JSON-based message handling in the `pubsub` package. The key changes include adding message subscription handlers for game state updates, publishing army movements to a topic exchange, and implementing a generic `SubscribeJSON` function for consuming and processing JSON messages.

### Changes in `cmd/client/main.go`:

**Message subscription and queue setup:**
* Added logic to declare and bind a new queue (`armyMovesQueue`) for handling army movement messages, and subscribed to it using the `handlerMove` function.
* Subscribed to a pause queue using the `handlerPause` function, enabling the client to handle game pause events.

**Publishing messages:**
* Implemented functionality to publish army movement commands to the topic exchange (`routing.ExchangePerilTopic`) with the appropriate routing key (`armyQueuesRoutingKey`).

**New helper functions:**
* Added `handlerPause` and `handlerMove` functions to process incoming pause and army movement messages, respectively, and update the game state.

### Changes in `internal/pubsub/pubsub.go`:

**Utility function for JSON message handling:**
* Introduced a generic `SubscribeJSON` function to simplify subscribing to queues and processing messages as JSON. This function handles message consumption, unmarshaling, and acknowledgment.