### PR TITLE
Add game logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,80 @@
-# learn-pub-sub-starter (Peril)
+# Peril - A Pub/Sub Based Strategy Game
 
-This is the starter code used in Boot.dev's [Learn Pub/Sub](https://learn.boot.dev/learn-pub-sub) course.
+Peril is a multiplayer strategy game that demonstrates the power of pub/sub architecture using RabbitMQ. Players can control armies, move units, and engage in wars with other players in real-time.
+
+## Features
+
+- Real-time multiplayer gameplay
+- Pub/Sub architecture using RabbitMQ
+- Army movement and unit management
+- War system with battle outcomes
+- Game state persistence
+- Event logging system
+
+## Prerequisites
+
+- Go 1.x or higher
+- RabbitMQ server running locally (or accessible via network)
+- Basic understanding of pub/sub patterns
+
+## Installation
+
+1. Clone the repository:
+```bash
+git clone https://github.com/yourusername/learn-pub-sub-starter.git
+cd learn-pub-sub-starter
+```
+
+2. Install dependencies:
+```bash
+go mod download
+```
+
+3. Ensure RabbitMQ is running:
+```bash
+# Default connection string: amqp://guest:guest@localhost:5672/
+```
+
+## Running the Game
+
+1. Start the game client:
+```bash
+go run cmd/client/main.go
+```
+
+2. Follow the on-screen prompts to:
+   - Enter your username
+   - Spawn units
+   - Move armies
+   - Engage in wars
+
+## Game Commands
+
+- `spawn <location> <unit_type>` - Spawn a new unit at the specified location
+- `move <location> <unit_id>` - Move a unit to a new location
+- `status` - View your current game state
+- `help` - Display available commands
+- `quit` - Exit the game
+
+## Architecture
+
+The game uses a pub/sub architecture with the following components:
+
+- **Direct Exchange**: Handles pause/resume game state
+- **Topic Exchange**: Manages army movements and war events
+- **Durable Queues**: Ensures war events persist across game sessions
+- **Transient Queues**: Handles temporary game state updates
+
+## Event Types
+
+1. **Army Moves**: Published when units are moved
+2. **War Events**: Triggered when armies from different players meet
+3. **Game Logs**: Record important game events and outcomes
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+## License
+
+This project is part of Boot.dev's [Learn Pub/Sub](https://learn.boot.dev/learn-pub-sub) course.

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/bootdotdev/learn-pub-sub-starter/internal/gamelogic"
 	"github.com/bootdotdev/learn-pub-sub-starter/internal/pubsub"
@@ -98,7 +99,7 @@ func main() {
 		log.Fatalf("Failed to subscribe to queue: %s\n", err)
 	}
 
-	err = pubsub.SubscribeJSON(conn, routing.ExchangePerilTopic, routing.WarRecognitionsPrefix, warSubscriptionRoutingKey, pubsub.Durable, handlerWar(gameState))
+	err = pubsub.SubscribeJSON(conn, routing.ExchangePerilTopic, routing.WarRecognitionsPrefix, warSubscriptionRoutingKey, pubsub.Durable, handlerWar(gameState, channel))
 	if err != nil {
 		log.Fatalf("Failed to subscribe to war queue: %s\n", err)
 	}
@@ -201,7 +202,7 @@ func handlerMove(gs *gamelogic.GameState, channel *amqp.Channel) func(gamelogic.
 	}
 }
 
-func handlerWar(gs *gamelogic.GameState) func(gamelogic.ArmyMove) pubsub.AckType {
+func handlerWar(gs *gamelogic.GameState, channel *amqp.Channel) func(gamelogic.ArmyMove) pubsub.AckType {
 	return func(am gamelogic.ArmyMove) pubsub.AckType {
 		defer fmt.Print("> ")
 
@@ -210,13 +211,31 @@ func handlerWar(gs *gamelogic.GameState) func(gamelogic.ArmyMove) pubsub.AckType
 			Attacker: am.Player,
 			Defender: gs.GetPlayerSnap(),
 		}
-		outcome, _, _ := gs.HandleWar(recognition)
+		outcome, winner, loser := gs.HandleWar(recognition)
 		switch outcome {
 		case gamelogic.WarOutcomeNotInvolved:
 			return pubsub.NackDiscard
 		case gamelogic.WarOutcomeNoUnits:
 			return pubsub.NackDiscard
 		case gamelogic.WarOutcomeOpponentWon, gamelogic.WarOutcomeYouWon, gamelogic.WarOutcomeDraw:
+			// Publish game log
+			var msg string
+			if outcome == gamelogic.WarOutcomeDraw {
+				msg = fmt.Sprintf("A war between %s and %s resulted in a draw", winner, loser)
+			} else {
+				msg = fmt.Sprintf("%s won a war against %s", winner, loser)
+			}
+			logEntry := routing.GameLog{
+				CurrentTime: time.Now(),
+				Message:     msg,
+				Username:    am.Player.Username,
+			}
+			logKey := fmt.Sprintf("%s.%s", routing.GameLogSlug, am.Player.Username)
+			err := pubsub.PublishGob(channel, routing.ExchangePerilTopic, logKey, logEntry)
+			if err != nil {
+				fmt.Printf("Failed to publish game log: %v\n", err)
+				return pubsub.NackRequeue
+			}
 			return pubsub.Ack
 		default:
 			fmt.Println("error: unknown war outcome")

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -228,12 +228,13 @@ func handlerWar(gs *gamelogic.GameState, channel *amqp.Channel) func(dw gamelogi
 			} else {
 				msg = fmt.Sprintf("%s won a war against %s", winner, loser)
 			}
+
 			logEntry := routing.GameLog{
 				CurrentTime: time.Now(),
 				Message:     msg,
-				Username:    am.Player.Username,
+				Username:    gs.Player.Username,
 			}
-			logKey := fmt.Sprintf("%s.%s", routing.GameLogSlug, am.Player.Username)
+			logKey := fmt.Sprintf("%s.%s", routing.GameLogSlug, gs.Player.Username)
 			err := pubsub.PublishGob(channel, routing.ExchangePerilTopic, logKey, logEntry)
 			if err != nil {
 				fmt.Printf("Failed to publish game log: %v\n", err)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -45,6 +45,21 @@ func main() {
 	}
 	fmt.Printf("Queue %s declared and bound\n", queueName)
 
+	// Subscribe to game logs
+	gameLogsRoutingKey := fmt.Sprintf("%s.*", routing.GameLogSlug)
+	err = pubsub.SubscribeGob(conn, routing.ExchangePerilTopic, routing.GameLogSlug, gameLogsRoutingKey, pubsub.Durable, func(log routing.GameLog) pubsub.AckType {
+		defer fmt.Print("> ")
+		err := gamelogic.WriteLog(log)
+		if err != nil {
+			fmt.Printf("Failed to write log: %v\n", err)
+			return pubsub.NackRequeue
+		}
+		return pubsub.Ack
+	})
+	if err != nil {
+		log.Fatalf("Failed to subscribe to game logs: %s\n", err)
+	}
+
 	gamelogic.PrintServerHelp()
 
 	for {
@@ -62,7 +77,7 @@ func main() {
 			err = pubsub.PublishJSON(channel, routing.ExchangePerilDirect, routing.PauseKey, routing.PlayingState{
 				IsPaused: true,
 			})
-		
+
 			if err != nil {
 				log.Printf("Failed to publish message: %s\n", err)
 				continue

--- a/internal/gamelogic/war.go
+++ b/internal/gamelogic/war.go
@@ -73,7 +73,7 @@ func isValidWarParticipant(player Player, rw RecognitionOfWar) bool {
 		return false
 	}
 
-	if player.Username != rw.Attacker.Username {
+	if player.Username != rw.Attacker.Username && player.Username != rw.Defender.Username {
 		fmt.Printf("%s, you are not involved in this war.\n", player.Username)
 		return false
 	}

--- a/internal/gamelogic/war.go
+++ b/internal/gamelogic/war.go
@@ -14,6 +14,13 @@ const (
 	WarOutcomeDraw
 )
 
+// UnitPower represents the power level of different unit types
+var UnitPower = map[UnitRank]int{
+	RankArtillery: 10,
+	RankCavalry:   5,
+	RankInfantry:  1,
+}
+
 func (gs *GameState) HandleWar(rw RecognitionOfWar) (outcome WarOutcome, winner string, loser string) {
 	defer fmt.Println("------------------------")
 	fmt.Println()
@@ -22,84 +29,100 @@ func (gs *GameState) HandleWar(rw RecognitionOfWar) (outcome WarOutcome, winner 
 
 	player := gs.GetPlayerSnap()
 
-	if player.Username == rw.Defender.Username {
-		fmt.Printf("%s, you published the war.\n", player.Username)
+	// Validate war participants
+	if !isValidWarParticipant(player, rw) {
 		return WarOutcomeNotInvolved, "", ""
 	}
 
-	if player.Username != rw.Attacker.Username {
-		fmt.Printf("%s, you are not involved in this war.\n", player.Username)
-		return WarOutcomeNotInvolved, "", ""
-	}
-
+	// Find overlapping location
 	overlappingLocation := getOverlappingLocation(rw.Attacker, rw.Defender)
 	if overlappingLocation == "" {
 		fmt.Printf("Error! No units are in the same location. No war will be fought.\n")
 		return WarOutcomeNoUnits, "", ""
 	}
 
-	attackerUnits := []Unit{}
-	defenderUnits := []Unit{}
-	for _, unit := range rw.Attacker.Units {
-		if unit.Location == overlappingLocation {
-			attackerUnits = append(attackerUnits, unit)
-		}
-	}
-	for _, unit := range rw.Defender.Units {
-		if unit.Location == overlappingLocation {
-			defenderUnits = append(defenderUnits, unit)
-		}
-	}
+	// Get units at the overlapping location
+	attackerUnits := getUnitsAtLocation(rw.Attacker.Units, Location(overlappingLocation))
+	defenderUnits := getUnitsAtLocation(rw.Defender.Units, Location(overlappingLocation))
 
-	fmt.Printf("%s's units:\n", rw.Attacker.Username)
-	for _, unit := range attackerUnits {
-		fmt.Printf("  * %v\n", unit.Rank)
-	}
-	fmt.Printf("%s's units:\n", rw.Defender.Username)
-	for _, unit := range defenderUnits {
-		fmt.Printf("  * %v\n", unit.Rank)
-	}
-	attackerPower := unitsToPowerLevel(attackerUnits)
-	defenderPower := unitsToPowerLevel(defenderUnits)
+	// Display unit information
+	displayWarUnits(rw.Attacker.Username, attackerUnits)
+	displayWarUnits(rw.Defender.Username, defenderUnits)
+
+	// Calculate power levels
+	attackerPower := calculatePowerLevel(attackerUnits)
+	defenderPower := calculatePowerLevel(defenderUnits)
 	fmt.Printf("Attacker has a power level of %v\n", attackerPower)
 	fmt.Printf("Defender has a power level of %v\n", defenderPower)
+
+	// Determine war outcome
+	outcome, winner, loser = determineWarOutcome(attackerPower, defenderPower, rw, player.Username)
+
+	// Handle unit removal based on outcome
+	if outcome == WarOutcomeDraw || (outcome == WarOutcomeOpponentWon && player.Username == rw.Attacker.Username) {
+		gs.removeUnitsInLocation(overlappingLocation)
+		fmt.Printf("Your units in %s have been killed.\n", overlappingLocation)
+	}
+
+	return outcome, winner, loser
+}
+
+func isValidWarParticipant(player Player, rw RecognitionOfWar) bool {
+	if player.Username == rw.Defender.Username {
+		fmt.Printf("%s, you published the war.\n", player.Username)
+		return false
+	}
+
+	if player.Username != rw.Attacker.Username {
+		fmt.Printf("%s, you are not involved in this war.\n", player.Username)
+		return false
+	}
+
+	return true
+}
+
+func getUnitsAtLocation(units map[int]Unit, location Location) []Unit {
+	var locationUnits []Unit
+	for _, unit := range units {
+		if unit.Location == location {
+			locationUnits = append(locationUnits, unit)
+		}
+	}
+	return locationUnits
+}
+
+func displayWarUnits(username string, units []Unit) {
+	fmt.Printf("%s's units:\n", username)
+	for _, unit := range units {
+		fmt.Printf("  * %v\n", unit.Rank)
+	}
+}
+
+func calculatePowerLevel(units []Unit) int {
+	power := 0
+	for _, unit := range units {
+		power += UnitPower[unit.Rank]
+	}
+	return power
+}
+
+func determineWarOutcome(attackerPower, defenderPower int, rw RecognitionOfWar, currentPlayer string) (WarOutcome, string, string) {
 	if attackerPower > defenderPower {
 		fmt.Printf("%s has won the war!\n", rw.Attacker.Username)
-		if player.Username == rw.Defender.Username {
+		if currentPlayer == rw.Defender.Username {
 			fmt.Println("You have lost the war!")
-			gs.removeUnitsInLocation(overlappingLocation)
-			fmt.Printf("Your units in %s have been killed.\n", overlappingLocation)
 			return WarOutcomeOpponentWon, rw.Attacker.Username, rw.Defender.Username
 		}
 		return WarOutcomeYouWon, rw.Attacker.Username, rw.Defender.Username
 	} else if defenderPower > attackerPower {
 		fmt.Printf("%s has won the war!\n", rw.Defender.Username)
-		if player.Username == rw.Attacker.Username {
+		if currentPlayer == rw.Attacker.Username {
 			fmt.Println("You have lost the war!")
-			gs.removeUnitsInLocation(overlappingLocation)
-			fmt.Printf("Your units in %s have been killed.\n", overlappingLocation)
 			return WarOutcomeOpponentWon, rw.Defender.Username, rw.Attacker.Username
 		}
 		return WarOutcomeYouWon, rw.Defender.Username, rw.Attacker.Username
 	}
-	fmt.Println("The war ended in a draw!")
-	fmt.Printf("Your units in %s have been killed.\n", overlappingLocation)
-	gs.removeUnitsInLocation(overlappingLocation)
-	return WarOutcomeDraw, rw.Attacker.Username, rw.Defender.Username
-}
 
-func unitsToPowerLevel(units []Unit) int {
-	power := 0
-	for _, unit := range units {
-		if unit.Rank == RankArtillery {
-			power += 10
-		}
-		if unit.Rank == RankCavalry {
-			power += 5
-		}
-		if unit.Rank == RankInfantry {
-			power += 1
-		}
-	}
-	return power
+	fmt.Println("The war ended in a draw!")
+	return WarOutcomeDraw, rw.Attacker.Username, rw.Defender.Username
 }


### PR DESCRIPTION
This pull request introduces enhancements to the `cmd/client` and `internal/pubsub` modules to improve functionality for handling and publishing game logs during war events. The key changes include extending the `handlerWar` function to publish detailed game logs using a new `PublishGob` method, which was added to the `pubsub` package.

### Enhancements to game log handling:
* [`cmd/client/main.go`](diffhunk://#diff-619f178fc713edfbdb03c328e1b880ee5a9097f611cd54b10f252c74d485fb92L204-R205): Updated the `handlerWar` function to accept an additional `channel` parameter and publish game logs for war outcomes. The logs include details such as the winner, loser, and timestamp, and are published using the `PublishGob` method. [[1]](diffhunk://#diff-619f178fc713edfbdb03c328e1b880ee5a9097f611cd54b10f252c74d485fb92L204-R205) [[2]](diffhunk://#diff-619f178fc713edfbdb03c328e1b880ee5a9097f611cd54b10f252c74d485fb92L213-R238)

### Updates to the `pubsub` package:
* [`internal/pubsub/pubsub.go`](diffhunk://#diff-389737051e0dee69a0c4b3ef1960998d1b946d0bd76f8bbaed3ce2ee8e81410aR49-R60): Added a new `PublishGob` function to publish messages encoded in the Gob format. This function uses a `bytes.Buffer` and `gob.Encoder` for encoding, and publishes messages with the `application/gob` content type.

### Supporting changes:
* [`cmd/client/main.go`](diffhunk://#diff-619f178fc713edfbdb03c328e1b880ee5a9097f611cd54b10f252c74d485fb92L101-R102): Modified the `SubscribeJSON` call in the `main` function to pass the `channel` parameter to the updated `handlerWar` function.
* [`cmd/client/main.go`](diffhunk://#diff-619f178fc713edfbdb03c328e1b880ee5a9097f611cd54b10f252c74d485fb92R7): Added the `time` package to support timestamping game logs.
* [`internal/pubsub/pubsub.go`](diffhunk://#diff-389737051e0dee69a0c4b3ef1960998d1b946d0bd76f8bbaed3ce2ee8e81410aR4-R6): Imported the `bytes` and `encoding/gob` packages to support the new `PublishGob` function.