### PR TITLE
Prefetch messages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM rabbitmq:3.13-management
+FROM rabbitmq:3.12-management
 RUN rabbitmq-plugins enable rabbitmq_stomp

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -162,7 +162,8 @@ func main() {
 			count, err := strconv.Atoi(words[1])
 
 			if err != nil {
-				fmt.Printf("Failed to parse %s, error: %w", words[1], err)
+				fmt.Printf("Failed to parse %s, error: %v", words[1], err)
+				continue
 			}
 
 			for i := 0; i < count; i++ {

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -176,12 +176,16 @@ func main() {
 					Username:    gameState.Player.Username,
 				}
 
-				pubsub.PublishGob(
+				err := pubsub.PublishGob(
 					channel,
 					routing.ExchangePerilTopic,
 					key,
 					logEntry,
 				)
+
+				if err != nil {
+					log.Printf("Failed to publish log exchange: %s key: %s: %v\n", routing.ExchangePerilTopic, key, err)
+				}
 			}
 
 		case "quit":

--- a/internal/pubsub/pubsub.go
+++ b/internal/pubsub/pubsub.go
@@ -111,7 +111,7 @@ func subscribe[T any](
 		return fmt.Errorf("failed to declare and bind: %w", err)
 	}
 
-	err = chn.Qos(10, 10, true)
+	err = chn.Qos(10, 0, true)
 	if err != nil {
 		return fmt.Errorf("failed to set prefetch count: %w", err)
 	}

--- a/internal/pubsub/pubsub.go
+++ b/internal/pubsub/pubsub.go
@@ -111,6 +111,11 @@ func subscribe[T any](
 		return fmt.Errorf("failed to declare and bind: %w", err)
 	}
 
+	err = chn.Qos(10, 10, true)
+	if err != nil {
+		return fmt.Errorf("failed to set prefetch count: %w", err)
+	}
+
 	msgs, err := chn.Consume(
 		queue.Name,
 		"",

--- a/internal/pubsub/pubsub.go
+++ b/internal/pubsub/pubsub.go
@@ -19,6 +19,10 @@ const (
 	Transient
 )
 
+const (
+	DefaultPrefetchCount = 10
+)
+
 type AckType int
 
 const (
@@ -111,7 +115,7 @@ func subscribe[T any](
 		return fmt.Errorf("failed to declare and bind: %w", err)
 	}
 
-	err = chn.Qos(10, 0, true)
+	err = chn.Qos(DefaultPrefetchCount, 0, true)
 	if err != nil {
 		return fmt.Errorf("failed to set prefetch count: %w", err)
 	}


### PR DESCRIPTION
This pull request includes updates to the `Dockerfile`, enhancements to the `cmd/client/main.go` file for improved functionality, and a modification in `internal/pubsub/pubsub.go` to optimize message consumption. Below is a summary of the most important changes:

### Dependency Updates:
* Updated the RabbitMQ base image in the `Dockerfile` from version `3.13-management` to `3.12-management`. This likely addresses compatibility or stability concerns.

### New Features in `cmd/client/main.go`:
* Added a new "spam" command that allows users to publish a specified number of malicious log messages. This includes parsing the command input, validating it, and publishing messages using the `pubsub.PublishGob` method.

### Code Enhancements in `cmd/client/main.go`:
* Added imports for `strconv` and `time` to support the new "spam" command functionality.
* Removed an unnecessary blank line after a subscription error check for better code readability.

### Performance Optimization in `internal/pubsub/pubsub.go`:
* Set a QoS (Quality of Service) prefetch count of 10 messages to optimize message consumption and ensure fair distribution of messages across consumers.This pull request introduces several updates to improve functionality and maintain compatibility. Key changes include downgrading the RabbitMQ version in the `Dockerfile`, adding a spam command in the client application, and setting a QoS prefetch count in the pub/sub implementation.

### Dependency Update:
* **Dockerfile**: Downgraded RabbitMQ from version `3.13-management` to `3.12-management` to address compatibility issues or ensure stability.

### New Features:
* **Spam Command**: Added a new `spam` command in `cmd/client/main.go` that allows users to send a specified number of malicious logs. This includes input validation, error handling, and publishing messages using the `pubsub.PublishGob` function.

### Code Enhancements:
* **QoS Prefetch Count**: Updated the `subscribe` function in `internal/pubsub/pubsub.go` to set a QoS prefetch count, limiting the number of unacknowledged messages to 10. This improves message handling efficiency.

### Minor Changes:
* **Imports in Client**: Added `strconv` and `time` imports in `cmd/client/main.go` to support new functionality.
* **Code Cleanup**: Removed an unnecessary blank line in the `main` function of `cmd/client/main.go` for better readability.