### PR TITLE
Update queue type handling in DeclareAndBind function

### DIFF
--- a/internal/pubsub/pubsub.go
+++ b/internal/pubsub/pubsub.go
@@ -23,6 +23,11 @@ const (
 	DefaultPrefetchCount = 10
 )
 
+const (
+	QueueClassicType   = "classic"
+	QueueClassicQuorum = "quorum"
+)
+
 type AckType int
 
 const (
@@ -70,9 +75,9 @@ func DeclareAndBind(conn *amqp.Connection, exchange, queueName, key string, simp
 	}
 
 	isTransient := simpleQueueType == Transient
-	queueType := "quorum"
+	queueType := QueueClassicQuorum
 	if isTransient {
-		queueType = "classic"
+		queueType = QueueClassicType
 	}
 
 	queue, err := chn.QueueDeclare(

--- a/internal/pubsub/pubsub.go
+++ b/internal/pubsub/pubsub.go
@@ -125,7 +125,7 @@ func subscribe[T any](
 		return fmt.Errorf("failed to declare and bind: %w", err)
 	}
 
-	// global is set to false because Quorum queues not not support the true value
+	// global is set to false because Quorum queues do not support the true value
 	err = chn.Qos(DefaultPrefetchCount, 0, false)
 	if err != nil {
 		return fmt.Errorf("failed to set prefetch count: %w", err)

--- a/internal/pubsub/pubsub.go
+++ b/internal/pubsub/pubsub.go
@@ -70,6 +70,10 @@ func DeclareAndBind(conn *amqp.Connection, exchange, queueName, key string, simp
 	}
 
 	isTransient := simpleQueueType == Transient
+	queueType := "quorum"
+	if isTransient {
+		queueType = "classic"
+	}
 
 	queue, err := chn.QueueDeclare(
 		queueName,
@@ -79,6 +83,7 @@ func DeclareAndBind(conn *amqp.Connection, exchange, queueName, key string, simp
 		false,
 		amqp.Table{
 			"x-dead-letter-exchange": routing.ExchangePerilDeadLetter,
+			"x-queue-type":           queueType,
 		},
 	)
 
@@ -115,7 +120,7 @@ func subscribe[T any](
 		return fmt.Errorf("failed to declare and bind: %w", err)
 	}
 
-	err = chn.Qos(DefaultPrefetchCount, 0, true)
+	err = chn.Qos(DefaultPrefetchCount, 0, false)
 	if err != nil {
 		return fmt.Errorf("failed to set prefetch count: %w", err)
 	}

--- a/internal/pubsub/pubsub.go
+++ b/internal/pubsub/pubsub.go
@@ -125,6 +125,7 @@ func subscribe[T any](
 		return fmt.Errorf("failed to declare and bind: %w", err)
 	}
 
+	// global is set to false because Quorum queues not not support the true value
 	err = chn.Qos(DefaultPrefetchCount, 0, false)
 	if err != nil {
 		return fmt.Errorf("failed to set prefetch count: %w", err)


### PR DESCRIPTION
- Introduced dynamic queue type selection based on the simpleQueueType, setting it to "quorum" for non-transient queues and "classic" for transient ones.
- Added the queue type to the QueueDeclare options to enhance queue configuration flexibility.
- Modified the prefetch count setting in the subscribe function to false, optimizing message consumption behavior.